### PR TITLE
Bugfix

### DIFF
--- a/content/itempools.xml
+++ b/content/itempools.xml
@@ -4,40 +4,40 @@
 		<Item Name="Blank Bombs" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Checked Mate" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Book of Despair" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-        <Item Name="​Donkey Jawbone" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+        <Item Name="Donkey Jawbone" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Lucky Seven" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Safety Bombs" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Max's Head" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Max's Head" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Ol' Lopper" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Melted Candle" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Dice Bombs" Weight="0.5" DecreaseBy="0.5" RemoveOn="0.05"/>
 	</Pool>
 	<Pool Name="shop">
 		<Item Name="Pill Crusher" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Voodoo Pin" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Voodoo Pin" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Beth's Heart" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Lunch Box" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Safety Bombs" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="devil">
-		<Item Name="​Pumpkin Mask" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Pumpkin Mask" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="curse">
-		<Item Name="​Voodoo Pin" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Voodoo Pin" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="angel">
-		<Item Name="​Menorah" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Menorah" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Bowl of Tears" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Ancient Revelation" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Pacifist" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Tammy's Tail" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Tammy's Tail" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="secret">
 		<Item Name="Dice Bombs" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Keeper's Rope" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Book of Illusions" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Melted Candle" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Tammy's Tail" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Tammy's Tail" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="ultraSecret">
 		<Item Name="Dice Bombs" Weight="1" DecreaseBy="0.4" RemoveOn="0.1"/>
@@ -57,30 +57,30 @@
 		<Item Name="Book of Despair" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
         <Item Name="Donkey Jawbone" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Safety Bombs" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Max's Head" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Max's Head" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Ol' Lopper" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Melted Candle" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="greedShop">
 		<Item Name="Pill Crusher" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Lucky Seven" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Voodoo Pin" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Voodoo Pin" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Beth's Heart" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Ol' Lopper" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Safety Bombs" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="greedDevil">
 		<Item Name="Book of Illusions" Weight="0.7" DecreaseBy="0.7" RemoveOn="0.07"/>
-		<Item Name="​Pumpkin Mask" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Pumpkin Mask" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="greedAngel">
-		<Item Name="​Menorah" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Menorah" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Bowl of Tears" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 		<Item Name="Ancient Revelation" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="greedSecret">
 		<Item Name="Keeper's Rope" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
-		<Item Name="​Tammy's Tail" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
+		<Item Name="Tammy's Tail" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>
 	</Pool>
 	<Pool Name="craneGame">
 		<Item Name="Lucky Seven" Weight="1" DecreaseBy="1" RemoveOn="0.1"/>

--- a/content/items.xml
+++ b/content/items.xml
@@ -4,49 +4,49 @@
 	<passive id="1" name="Blank Bombs" description="Enter the basement" gfx="collectibles_002_blank_bombs.png" bombs="5" quality="2" tags="summonable offensive"/>
 	<familiar id="2" name="Checked Mate" description="Chess friend" gfx="collectibles_003_checked_mate.png" quality="3" tags="summonable monstermanual offensive"/>
 	<passive id="3" name="Dice Bombs" description="Item reroller +5 bombs" gfx="collectibles_004_dice_bombs.png" bombs="5" quality="4" tags="summonable offensive"/>
-	<passive id="4" name="​Donkey Jawbone" description="Come at me!" gfx="collectibles_005_donkey_jawbone.png" quality="2" tags="nolostbr summonable" achievement="452"/>
-    <familiar id="5" name="​Menorah" description="Shot multiplier" gfx="collectibles_006_menorah.png" quality="4" tags="uniquefamiliar summonable nolostbr" cache="firedelay" />
+	<passive id="4" name="Donkey Jawbone" description="Come at me!" gfx="collectibles_005_donkey_jawbone.png" quality="2" tags="nolostbr summonable" achievement="452"/>
+	<familiar id="5" name="Menorah" description="Shot multiplier" gfx="collectibles_006_menorah.png" quality="4" tags="uniquefamiliar summonable nolostbr" cache="firedelay" />
 	
 	<passive id="6" name="Ancient Revelation" description="Remember what came before" gfx="collectibles_007_ancient_revelation.png" achievement="470" cache="firedelay shotspeed flying tearcolor tearflag tearsup" soulhearts="4" devilprice="2" quality="4" tags="summonable offensive angel" />
-    <familiar id="7" name="Beth's Heart" description="Faith accumulator" gfx="collectibles_008_beths_heart.png" achievement="404" quality="1" tags="summonable offensive"/>   
-    <passive id="8" name="Keeper's Rope" description="Beat the money out of them" gfx="collectibles_009_keepers_rope.png" achievement="251" cache="flying luck" quality="3" tags="summonable offensive" />
-    <passive id="9" name="Lucky Seven" description="Fortune favors the bold" gfx="collectibles_010_lucky_seven.png" quality="2" cache="luck" tags="summonable offensive"/>
-    <passive id="10" name="Pacifist" description="Make love, not war" gfx="collectibles_011_pacifist.png" quality="2" tags="summonable offensive nocantrip nogreed lazarusshared" />
+	<familiar id="7" name="Beth's Heart" description="Faith accumulator" gfx="collectibles_008_beths_heart.png" achievement="404" quality="1" tags="summonable offensive"/>   
+	<passive id="8" name="Keeper's Rope" description="Beat the money out of them" gfx="collectibles_009_keepers_rope.png" achievement="251" cache="flying luck" quality="3" tags="summonable offensive" />
+	<passive id="9" name="Lucky Seven" description="Fortune favors the bold" gfx="collectibles_010_lucky_seven.png" quality="2" cache="luck" tags="summonable offensive"/>
+	<passive id="10" name="Pacifist" description="Make love, not war" gfx="collectibles_011_pacifist.png" quality="2" tags="summonable offensive nocantrip nogreed lazarusshared" />
 	<passive id="11" name="Safety Bombs" description="For your own good" gfx="collectibles_012_safety_bombs.png" bombs="7" quality="0" tags="summonable"/>
-    <passive id="12" name="Ol' Lopper" description="A new point of view" gfx="collectibles_013_ol_lopper.png" quality="1" tags="summonable offensive" cache="familiars"/>
-    <passive id="13" name="​Max's Head" description="Tears up" gfx="collectibles_014_maxs_head.png" quality="3" cache="firedelay" tags="summonable offensive tearsup"/>
+	<passive id="12" name="Ol' Lopper" description="A new point of view" gfx="collectibles_013_ol_lopper.png" quality="1" tags="summonable offensive" cache="familiars"/>
+	<passive id="13" name="Max's Head" description="Tears up" gfx="collectibles_014_maxs_head.png" quality="3" cache="firedelay" tags="summonable offensive tearsup"/>
 	<!-- Active Items -->
 	<active id="14" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
-	<active id="15" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
-	<active id="16" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
-	<active id="17" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
-	<active id="18" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
-	<active id="19" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" tags="offensive" />
-	<active id="20" name="Book of Despair" description="Temporary tears up" gfx="collectibles_016_book_of_despair.png" maxcharges="3" quality="3" cache="firedelay" tags="book offensive lazarussharedglobal" />
-	<active	id="21" name="Bowl of Tears" description="Splash!" gfx="collectibles_017_bowl_of_tears.png" maxcharges="6" chargetype="special" quality="4" tags="offensive"/>
+	<active id="14" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
+	<active id="14" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
+	<active id="14" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
+	<active id="14" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" hidden="true"/>
+	<active id="14" name="Lunch Box" description="Portable buffet" gfx="collectibles_015_lunch_box.png" quality="2" maxcharges="6" shopprice="10" initcharge="0" chargetype="special" tags="offensive" />
+	<active id="15" name="Book of Despair" description="Temporary tears up" gfx="collectibles_016_book_of_despair.png" maxcharges="3" quality="3" cache="firedelay" tags="book offensive lazarussharedglobal" />
+	<active	id="16" name="Bowl of Tears" description="Splash!" gfx="collectibles_017_bowl_of_tears.png" maxcharges="6" chargetype="special" quality="4" tags="offensive"/>
 	
-	<active id="22" name="Book of Illusions" description="Army of you" gfx="collectibles_018_book_of_illusions.png" maxcharges="12" quality="4" tags="book offensive" />
-	<active id="23" name="Pill Crusher" description="Drug dealer" gfx="collectibles_019_pill_crusher.png" quality="1" shopprice="10" tags="offensive nocantrip" />
-	<active id="24" name="​Voodoo Pin" description="Share your pain" gfx="collectibles_020_voodoo_pin.png" maxcharges="3" chargetype="normal" quality="2" tags="offensive" />
+	<active id="17" name="Book of Illusions" description="Army of you" gfx="collectibles_018_book_of_illusions.png" maxcharges="12" quality="4" tags="book offensive" />
+	<active id="18" name="Pill Crusher" description="Drug dealer" gfx="collectibles_019_pill_crusher.png" quality="1" shopprice="10" tags="offensive nocantrip" />
+	<active id="19" name="Voodoo Pin" description="Share your pain" gfx="collectibles_020_voodoo_pin.png" maxcharges="3" chargetype="normal" quality="2" tags="offensive" />
 	
-	<passive id="25" name="​Pumpkin Mask" description="Harvest moon curse" gfx="collectibles_021_pumpkin_mask.png" quality="2" cache="firedelay" tags="offensive summonable" />
-	<passive id="26" name="Melted Candle" description="Tears up + wavering heat" gfx="collectibles_022_melted_candle.png" quality="2" cache="firedelay" tags="offensive summonable tearsup"/>
-	<passive id="27" name="​Tammy's Tail" description="Crying out for love" gfx="collectibles_023_tammys_tail.png" quality="2" cache="firedelay" tags="offensive summonable nolostbr tearsup" />
+	<passive id="20" name="Pumpkin Mask" description="Harvest moon curse" gfx="collectibles_021_pumpkin_mask.png" quality="2" cache="firedelay" tags="offensive summonable" />
+	<passive id="21" name="Melted Candle" description="Tears up + wavering heat" gfx="collectibles_022_melted_candle.png" quality="2" cache="firedelay" tags="offensive summonable tearsup"/>
+	<passive id="22" name="Tammy's Tail" description="Crying out for love" gfx="collectibles_023_tammys_tail.png" quality="2" cache="firedelay" tags="offensive summonable nolostbr tearsup" />
 
 	<!-- Trinkets -->
-	<trinket id="0" name="​Game Squid" description="Leaky buddy" gfx="trinket_001_game_squid.png" />
+	<trinket id="0" name="Game Squid" description="Leaky buddy" gfx="trinket_001_game_squid.png" />
 
 	<!--Reimplemented Transformations-->
-    <passive name="Spun transform" description="Counts towards spun" hidden="true" tags="syringe"/>
-    <passive name="Mom transform" description="Counts towards mom" hidden="true" tags="mom"/>
-    <passive name="Guppy transform" description="Counts towards guppy" hidden="true" tags="guppy"/>
-    <passive name="Fly transform" description="Counts towards fly" hidden="true" tags="fly"/>
-    <passive name="Bob transform" description="Counts towards bob" hidden="true" tags="bob"/>
-    <passive name="Mushroom transform" description="Counts towards mushroom" hidden="true" tags="mushroom"/>
-    <passive name="Baby transform" description="Counts towards baby" hidden="true" tags="baby"/>
-    <passive name="Angel transform" description="Counts towards angel" hidden="true" tags="angel"/>
-    <passive name="Devil transform" description="Counts towards devil" hidden="true" tags="devil"/>
-    <passive name="Poop transform" description="Counts towards poop" hidden="true" tags="poop"/>
-    <passive name="Book transform" description="Counts towards book" hidden="true" tags="book"/>
-    <passive name="Spider transform" description="Counts towards spider" hidden="true" tags="spider"/>
+	<passive name="Spun transform" description="Counts towards spun" hidden="true" tags="syringe"/>
+	<passive name="Mom transform" description="Counts towards mom" hidden="true" tags="mom"/>
+	<passive name="Guppy transform" description="Counts towards guppy" hidden="true" tags="guppy"/>
+	<passive name="Fly transform" description="Counts towards fly" hidden="true" tags="fly"/>
+	<passive name="Bob transform" description="Counts towards bob" hidden="true" tags="bob"/>
+	<passive name="Mushroom transform" description="Counts towards mushroom" hidden="true" tags="mushroom"/>
+	<passive name="Baby transform" description="Counts towards baby" hidden="true" tags="baby"/>
+	<passive name="Angel transform" description="Counts towards angel" hidden="true" tags="angel"/>
+	<passive name="Devil transform" description="Counts towards devil" hidden="true" tags="devil"/>
+	<passive name="Poop transform" description="Counts towards poop" hidden="true" tags="poop"/>
+	<passive name="Book transform" description="Counts towards book" hidden="true" tags="book"/>
+	<passive name="Spider transform" description="Counts towards spider" hidden="true" tags="spider"/>
 </items>

--- a/lua/core/enums.lua
+++ b/lua/core/enums.lua
@@ -148,8 +148,8 @@ Enums.CollectibleType =
 						COLLECTIBLE_BLANK_BOMBS = Isaac.GetItemIdByName("Blank Bombs"),
 						COLLECTIBLE_CHECKED_MATE = Isaac.GetItemIdByName("Checked Mate"),
 						COLLECTIBLE_DICE_BOMBS = Isaac.GetItemIdByName("Dice Bombs"),
-						COLLECTIBLE_DONKEY_JAWBONE = Isaac.GetItemIdByName("​Donkey Jawbone"),
-						COLLECTIBLE_MENORAH = Isaac.GetItemIdByName("​Menorah"),
+						COLLECTIBLE_DONKEY_JAWBONE = Isaac.GetItemIdByName("Donkey Jawbone"),
+						COLLECTIBLE_MENORAH = Isaac.GetItemIdByName("Menorah"),
 						COLLECTIBLE_ANCIENT_REVELATION = Isaac.GetItemIdByName("Ancient Revelation"),
 						COLLECTIBLE_BETHS_HEART = Isaac.GetItemIdByName("Beth's Heart"),
 						COLLECTIBLE_KEEPERS_ROPE = Isaac.GetItemIdByName("Keeper's Rope"),
@@ -157,20 +157,20 @@ Enums.CollectibleType =
 						COLLECTIBLE_PACIFIST = Isaac.GetItemIdByName("Pacifist"),
 						COLLECTIBLE_SAFETY_BOMBS = Isaac.GetItemIdByName("Safety Bombs"),
 						COLLECTIBLE_OL_LOPPER = Isaac.GetItemIdByName("Ol' Lopper"),
-						COLLECTIBLE_MAXS_HEAD = Isaac.GetItemIdByName("​Max's Head"),
+						COLLECTIBLE_MAXS_HEAD = Isaac.GetItemIdByName("Max's Head"),
 						COLLECTIBLE_LUNCH_BOX = Isaac.GetItemIdByName("Lunch Box"),
 						COLLECTIBLE_BOOK_OF_DESPAIR = Isaac.GetItemIdByName("Book of Despair"),
 						COLLECTIBLE_BOWL_OF_TEARS = Isaac.GetItemIdByName("Bowl of Tears"),
 						COLLECTIBLE_BOOK_OF_ILLUSIONS = Isaac.GetItemIdByName("Book of Illusions"),
 						COLLECTIBLE_PILL_CRUSHER = Isaac.GetItemIdByName("Pill Crusher"),
-						COLLECTIBLE_VOODOO_PIN = Isaac.GetItemIdByName("​Voodoo Pin"),
-						COLLECTIBLE_PUMPKIN_MASK = Isaac.GetItemIdByName("​Pumpkin Mask"),
+						COLLECTIBLE_VOODOO_PIN = Isaac.GetItemIdByName("Voodoo Pin"),
+						COLLECTIBLE_PUMPKIN_MASK = Isaac.GetItemIdByName("Pumpkin Mask"),
 						COLLECTIBLE_MELTED_CANDLE = Isaac.GetItemIdByName("Melted Candle"),
-						COLLECTIBLE_TAMMYS_TAIL_TC = Isaac.GetItemIdByName("​Tammy's Tail"),
+						COLLECTIBLE_TAMMYS_TAIL_TC = Isaac.GetItemIdByName("Tammy's Tail"),
 					}
 
 Enums.TrinketType = {
-						TRINKET_GAME_SQUID_TC = Isaac.GetTrinketIdByName("​Game Squid"),
+						TRINKET_GAME_SQUID_TC = Isaac.GetTrinketIdByName("Game Squid"),
 					}
 
 Enums.Pickups = 

--- a/lua/mod_compat/eid/eid.lua
+++ b/lua/mod_compat/eid/eid.lua
@@ -146,7 +146,7 @@ EID:addCollectible(RestoredCollection.Enums.CollectibleType.COLLECTIBLE_MENORAH,
 
 if Sewn_API then
     Sewn_API:AddFamiliarDescription(
-        FamiliarVariant.MENORAH,
+        RestoredCollection.Enums.Familiars.MENORAH.Variant,
         "Higher fire rate per flame",
         "Higher fire rate per flame#You can keep firing even with no flames"
     )


### PR DESCRIPTION
- Remove zero-width spaces in certain item names, as they are unsupported characters when rendered in-game and overall unnecessary to have (why were they there in the first place? and why is there a dedicated function to removing them? why not just remove them from the .xml file???)
- Fix item IDs, and do them like how they were before (meaning all the Lunch Box IDs are 14 instead of incrementing. otherwise, the items in the stat page don't show their correct icons. but also why are there 5 hidden lunch box items in the first place? they don't have any function in-game from what i could tell, do they?)
- Fix a bug where Sewing Machine API didn't initialize Menorah's familiar upgrade descriptions properly, causing the latter half of eid.lua to not execute and be read at all (meaning half the items didn't have their external item descriptions initialized either if Sewing Machine was enabled)